### PR TITLE
Support arbitrarily nested projects on any OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,11 @@ jobs:
         with:
           fetch-depth: 0
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to ${{ github.workspace }} on the runner."
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
+      - run: echo "." >> $GITHUB_PATH
       - run: make venv
       - run: make syntax
       - run: make style
@@ -26,12 +27,11 @@ jobs:
       - run: make example/syntax
       - run: make example/style
       - run: make example/bringup
-      - run: ( cd example && ./test.py )
+      - run: ( cd example && greeter.py )
       - run: make example/tested
       - run: make example/report
       - run: make example/gfm
       - run: make report
-      - run: make clean && make report
       - run: make old  # Building last release
       - run: make old  # Just printing last release
       - run: make new
@@ -41,5 +41,5 @@ jobs:
       - run: make prompt
       - run: make prompt
       - run: make audit
-      - run: make audit
+      - run: make clean && make audit
       - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,10 @@ _NAME := $(notdir $(realpath $/.))
 # If $/ *is* used within a recipy, that whole recipy needs to be expanded before the rule is defined, like this:
 
     define META
-        $/meta-recipy:
-	        # $$@: $$^ - Every $$ except the $$/ in the recipy needs to be doubled now!
+        $$/meta-recipy:
+	        # $$@: $$^ - Every $$ except a wanted expansion of $$/ = $/ in the recipy needs to be doubled now!
 	        echo "Like this: $$$$$$$$PATH = $$$$PATH"
 	        # And the recipy itself needs to be be defined by`$$(eval ...)`-ing it first.
-            # This recipy will execute every `make meta-recipy` since $$@ is never done by it.
     endef
     $(eval $(META))
 
@@ -96,10 +95,12 @@ _NAME := $(notdir $(realpath $/.))
 
 #### Recommended dependencies
 
-# `build/*.py.bringup`: *.py is executable using a venv/bin/python3 next to it.
-# `build/directory-name.bringup`: ./directory-name is executable as-is.
+# `bringup`: All code in the project is executable as bare shell commands, including .py files.
+# `build/*.py.bringup`: *.py is executable by the venv/bin/python3 next to it.
+# `build/*.py.shebang`: *.py has the local python shebang #!venv/bin/python3
+# `build/directory-name.bringup`: directory-name is an executable that contains all compilable sources.
 # `build/*.tested`: * is self-tested without failure, and the test output is here.
-# `build/*.md`: * is documented here.
+# `build/*.md`: * is documented here. Make *.gfm *.pdf *.html to translate it to your desired pandoc format.
 
 #### Binary executable
 
@@ -326,21 +327,19 @@ $/_SUBPROJECTS += $(sort $(dir $(foreach d,$($/_SUBDIRS),$(wildcard $/$d/*.md)))
 $/_SUBPROJECTS := $(filter-out $($/_NON-SUBPROJECTS),$($/_SUBPROJECTS))
 $/_ACTIVE_SUBPROJECTS := $(dir $(foreach d,$($/_SUBPROJECTS),$(wildcard $/$dMakefile)))
 
-#### Make sub-projects before this project
-
-$/all: | $($/_ACTIVE_SUBPROJECTS:%=%all)
-$/tested: | $($/_ACTIVE_SUBPROJECTS:%=%tested)
-$/report: | $($/_ACTIVE_SUBPROJECTS:%=%report)
-$/gfm: | $($/_ACTIVE_SUBPROJECTS:%=%gfm)
-$/pdf: | $($/_ACTIVE_SUBPROJECTS:%=%pdf)
-$/html: | $($/_ACTIVE_SUBPROJECTS:%=%html)
-$/slides: | $($/_ACTIVE_SUBPROJECTS:%=%slides)
-$/old: | $($/_ACTIVE_SUBPROJECTS:%=%old)
-$/new: $($/_ACTIVE_SUBPROJECTS:%=%new)
-$/build/review.diff: $($/_ACTIVE_SUBPROJECTS:%=%build/review.diff)
-
-#### Remove all built files in all projects
+# Define symbolic targets we might want to use to represent (all) its dependencies
+# Do not use such a phony as a dependency unless you also need the target rebuilt every time.
 define META
+    .PHONY: $/all $$/bringup $/tested $/old $/new $/html $/pdf $/slides $/clean $/clean/keep_venv
+    .PHONY: $venv/ $/syntax $/style
+    $/all: | $($/_ACTIVE_SUBPROJECTS:%=%all)
+    $/tested: | $($/_ACTIVE_SUBPROJECTS:%=%tested)
+    $/report: | $($/_ACTIVE_SUBPROJECTS:%=%report)
+    $/pdf: | $($/_ACTIVE_SUBPROJECTS:%=%pdf)
+    $/slides: | $($/_ACTIVE_SUBPROJECTS:%=%slides)
+    $/old: | $($/_ACTIVE_SUBPROJECTS:%=%old)
+    $/new: $/gfm | $($/_ACTIVE_SUBPROJECTS:%=%new)
+    $/build/review.diff: $($/_ACTIVE_SUBPROJECTS:%=%build/review.diff)
     $/clean: $/clean/keep_venv | $($/_ACTIVE_SUBPROJECTS:%=%clean)
 	    rm -rf $/venv/ $/.ruff_cache/
     $/clean/keep_venv: | $($/_ACTIVE_SUBPROJECTS:%=%clean/keep_venv)
@@ -405,8 +404,8 @@ ifndef $($/_HOME_DIR)
     $($/_HOME_DIR) := $($/_HOME_DIR))
     #$/_SUBPROJECTS += $($/_HOME)build/$($/_BASELINE)/
     define META
-        $($/_HOME)build/$($/_BASELINE)/Makefile:
-	        git worktree add -d $$(dir $$@) $($/_BASELINE)
+        $$($$/_HOME)build/$$($$/_BASELINE)/Makefile:
+	        git worktree add -d $$(dir $$@) $$($/_BASELINE)
     endef
     $(eval $(META))
 endif
@@ -473,6 +472,7 @@ $/_EXES += $($/*.py)
 
 # Collect bringup and tested targets
 $/build/*.bringup := $($/*.py:$/%=$/build/%.bringup)
+$/build/*.bringup += $($/*.py:$/%=$/build/%.shebang)
 $/build/*.tested += $($/*.py:$/%=$/build/%.tested)
 $/_PRETESTED := $($/build/*.tested)
 $/build/*.tested += $($/*.md:$/%=$/build/%.sh-test.tested)
@@ -524,9 +524,25 @@ endif
 .SUFFIXES:
 
 # Convenience targets
-.PHONY: $/bringup $/tested $/clean
-$/bringup: $($/_EXE) $($/build/*.bringup)
-$/tested: $($/build/*.tested)
+define META
+    $/venv: $/venv/bin/python3
+    $/bringup: $($/_EXE) $($/build/*.bringup)
+    $/tested: $($/build/*.tested)
+    $/syntax: $($/*.py:$/%=$/build/%.syntax)
+    $/style: $($/*.py:$/%=$/build/%.style)
+    $/old: $($/_OLD)report.gfm
+	    @echo "# file://$$(subst /mnt/c/,/C:/,$$(realpath $$<)) $$($/_BASELINE_INFO)"
+    $/new: $/report.gfm $($/build/*.tested)
+	    @echo "# file://$$(subst /mnt/c/,/C:/,$$(realpath $$<)) $$($/_BRANCH_STATUS)"
+    $/%: $/report.% $($/build/*.tested)
+	    @echo "# file://$$(subst /mnt/c/,/C:/,$$(realpath $$<)) $$($/_BRANCH_STATUS)"
+    $/%: $/build/%.diff $($/build/*.tested)
+	    @echo "# file://$$(subst /mnt/c/,/C:/,$$(realpath $$<)) $$($/_CHANGES)"
+endef
+$(eval $(META))
+
+$/slides.html: $/report.dzslides
+	cp $< $@
 
 # Use the clang compiler
 $?/clang++: $?/clang
@@ -541,22 +557,21 @@ ifneq (,$($/_OBJS))
     # Use project specific compile flags
     define META
         # Compile C++
-        $/build/%.cpp.s: $/%.cpp | $(CXX)
-	        $(CXX) $($/_CXXFLAGS) -c $$< -o $$@
+        $$/build/%.cpp.s: $$/%.cpp | $$(CXX)
+	        $$(CXX) $$($/_CXXFLAGS) -c $$< -o $$@
 
         # Compile C
-        $/build/%.c.s: $/%.c | $(CXX)
-	        $(CXX) $($/_CFLAGS) -c $$< -o $$@
+        $$/build/%.c.s: $$/%.c | $$(CXX)
+	        $$(CXX) $$($/_CFLAGS) -c $$< -o $$@
 
         # Link executable
-        $/$($/_NAME): $($/_OBJS) | $(CC)
-	        $(CC) $($/_LDFLAGS) $$^ -o $$@
+        $$/$$($$/_NAME): $$($$/_OBJS) | $$(CC)
+	        $$(CC) $$($/_LDFLAGS) $$^ -o $$@
     endef
     $(eval $(META))
 endif
 
 # Check Python 3.9 syntax
-$/syntax: $/build/syntax
 $/build/%.py.syntax: $($/venv/bin/python3) $/%.py | $($/venv/pip/)ruff
 	$< -m ruff check --select=E9,F63,F7,F82 --target-version=py39 $(lastword,$^) > $@ || (cat $@ && false)
 
@@ -613,15 +628,18 @@ $/build/%.py.style: $/%.py $/build/%.py.syntax $($/venv/bin/python3)
 $/build/%.py.mk: $/%.py | $/makemake.py
 	rm -f $@ && ( cd $(dir $<). && $(PYTHON) $*.py --generic --dep build/$*.py.mk ) ; [ -e $@ ] || echo "\$$/build/$*.py.bringup:; touch \$$@" > $@
 
+# Make a .py file executable
+$/build/%.py.shebang: $($/venv/bin/python3) $/%.py
+	$^ --shebang > $@
+
 # Check Python and command line usage examples in .py files
-$/build/%.py.tested: $/. $/%.py $/build/%.py.mk $/build/%.py.style $/build/%.py.bringup $($/_EXE_TESTED) | $($/venv/bin/python3)
+$/build/%.py.tested: $/. $/%.py $/build/%.py.mk $/build/%.py.style $/build/%.py.bringup $/build/%.py.shebang $($/_EXE_TESTED) | $($/venv/bin/python3)
 	( cd $< && $*.py --test ) > $@ || (cat $@ && false)
 
 # Check command line usage examples in .md files
 $/build/%.sh-test.tested: $/. $($/_PRETESTED) $/build/%.sh-test | $/makemake.py
 	tmp=$@-$$(if [ -e $@-0 ] ; then echo 1 ; else echo 0 ; fi) && \
 	( cd $< && $(PYTHON) makemake.py --timeout 60 --sh-test $(patsubst $(dir $<)%,%,$(lastword $^)) ) > $$tmp && mv $$tmp $@
-$($/build/%.md.sh-test: $/%.md | $?/pandoc $?/jq)
 $/build/%.md.sh-test: $/%.md | $?/pandoc $?/jq
 	pandoc -i $< -t json --preserve-tabs | jq -r '.blocks[] | select(.t | contains("CodeBlock"))? | .c | select(.[0][1][0] | contains("sh"))? | .[1]' > $@ && truncate -s -1 $@
 
@@ -631,140 +649,106 @@ $/report: $/build/report.txt
 $/build/report.txt: $($/build/*.tested)
 	( $(foreach t,$^,echo "___ $(t): ____" && cat $(t) ; ) ) > $@
 
+# Make a markdown document.
+ifndef __
+    _file = $(foreach _,$1,[\`$_\`]($_))
+    _exe = $(foreach _,$1,[\`$_\`]($_))
+    _help_fixup := sed -E '/^$$$$|[.]{3}/d'
+    _heading := \n---\n\n\#
+    _link = [$1]($1)
+    _. = \\\\footnotesize\n~~~ {$1}
+    _sh := $(call _.,.sh)
+    __ := ~~~\n\\\\normalsize\n
+endif
+
+$/build/Makefile.md: $/Makefile
+	( echo "$(_heading)## $(call _link,Makefile)" && echo "$(call _.,.mk)" && cat $< && echo "$(__)" ) > $@
+$/build/%.md: $/%
+	( echo "$(_heading)## $(call _link,$*)" && echo "$(call _.,$(suffix $<))" && cat $< && echo "$(__)" ) > $@
+$/build/%.md: $/build/%
+	( echo "$(_heading)## $(call _link,build/$*)" && echo "$(call _.,$(suffix $<))" && cat $< && echo "$(__)" ) > $@
+$/build/%.bringup.md: $/build/%.bringup
+	( echo "$(_heading)## $(call _link,build/$*.bringup)" && echo "$(_sh)" && cat $< && echo "$(__)" ) > $@
+$/build/%.tested.md: $/build/%.tested
+	( echo "$(_heading)## $(call _link,build/$*.tested)" && echo "$(_sh)" && cat $< && echo "$(__)" ) > $@
+
 # Make a standalone gfm, html, pdf, or dzslides document.
 define META
-    $/%.gfm: $/build/%.md
+    $$/build/report.md: | $$/tested
+	    echo "A build-here include-from-anywhere project based on [makemake](https://github.com/joakimbits/normalize)." > $$@
+	    echo "\n- \`make report pdf html slides review audit\`" >> $$@
+ifneq ($(strip $($/_EXE)),)
+	    echo "- \`./$$($/_NAME)\`: $$(call _file,$$($/_LINKABLE:$/%=%))" >> $$@
+endif
+ifneq (,$(strip $($/*.py)))
+	    echo "- $$(call _exe,$$($/*.py:$/%=%))" >> $$@
+endif
+	    echo "$$(_heading)## Installation" >> $$@
+	    echo "$$(_sh)" >> $$@
+	    echo "$$$$ make" >> $$@
+	    echo "$$(__)" >> $$@
+ifneq (,$(strip $($/_EXE)))
+	    echo "- Installs \`./$$($/_NAME)\`." >> $$@
+endif
+ifneq (,$(strip $($/*.py)))
+	    echo "- Installs $$(call _exe,venv/bin/python3)." >> $$@
+	    echo "- Installs $$(call _exe,$$($/*.py:$/%=%))." >> $$@
+endif
+ifneq (,$($/_EXES))
+	    echo "$$(_heading)## Usage" >> $$@
+	    echo "$$(_sh)" >> $$@
+	    for x in $$($/_EXES:$/%=%) ; do \
+	      echo "\$$$$ true | $$$$x -h | $$(_help_fixup)" >> $$@ && \
+	      ( cd $/. && true | $$$$x -h ) > $$@.tmp && \
+	      $$(_help_fixup) $$@.tmp >> $$@ && rm $$@.tmp ; \
+	    done
+	    echo >> $$@
+	    echo "$$(__)" >> $$@
+	    echo "$$(_heading)## Test" >> $$@
+	    echo "$$(_sh)" >> $$@
+	    echo "\$$$$ make tested" >> $$@
+	    echo "$$(__)" >> $$@
+endif
+ifneq (,$(strip $($/_EXE)))
+	    echo "- Tests \`./$$($/_NAME)\`." >> $$@
+endif
+ifneq (,$(strip $($/*.py)))
+	    echo "- Verifies style and doctests in $$(call _file,$$($/*.py:$/%=%))." >> $$@
+endif
+ifneq (,$(strip $($/*.md)))
+	     echo "- Verifies doctests in $$(call _file,$$($/*.md:$/%=%))." >> $$@
+endif
+ifneq (,$(strip $($/_CODE)))
+	    echo "$$(_heading)## Result" >> $$@
+	    echo "$$(_sh)" >> $$@
+	    echo "\$$$$ make report" >> $$@
+	    ( cd $/. && $$(MAKE) report --no-print-directory ) >> $$@
+	    echo "$$(__)" >> $$@
+	    echo "\n---\n" >> $$@
+endif
+
+    $$/%.gfm: $/build/%.md
 	    pandoc --standalone -t $$(patsubst .%,%,$$(suffix $$@)) -o $$@ $$^ \
-	           -M title="$($/_NAME) $$*" -M author="`git log -1 --pretty=format:'%an'`"
-    $/%.html $/%.pdf $/%.dzslides: $/build/%.md | $?/pandoc $?/xetex $(CARLITO)/Carlito-Regular.ttf $(COUSINE)/Cousine-Regular.ttf
+	           -M title="$$($/_NAME) $$*" -M author="`git log -1 --pretty=format:'%an'`"
+    $$/%.html $$/%.pdf $$/%.dzslides: $$/build/%.md | $$?/pandoc $$?/xetex $(CARLITO)/Carlito-Regular.ttf $(COUSINE)/Cousine-Regular.ttf
 	    pandoc --standalone -t $$(patsubst .%,%,$$(suffix $$@)) -o $$@ $$^ \
 	           -M title="$$($/_NAME) $$*" -M author="`git log -1 --pretty=format:'%an'`" \
 	           -V min-width=80%\!important -V geometry:margin=1in \
 	           --pdf-engine=xelatex -V mainfont="Carlito" -V monofont="Cousine"
 endef
 $(eval $(META))
+$/report.gfm $/report.html $/report.pdf $/report.dzslides: $($/*.md) $($/_REPORT)
 
-# Make a markdown document.
-ifndef __
-    _h := \n---\n\n\#
-    _. = \\\\footnotesize\n~~~ {$1}
-    _sh := $(call _.,.sh)
-    __ := ~~~\n\\\\normalsize\n
-endif
-define META
-    $/build/Makefile.md: $/Makefile
-	    ( echo "$(_h)## [Makefile](Makefile)" && \
-	      echo "$(call _.,.mk)" && \
-	      cat $$< && echo "$(__)" ) > $$@
-    $/build/%.md: $/%
-	    ( echo "$(_h)## [$$*]($$*)" && \
-	      echo "$$(call _.,$$(suffix $$<))" && \
-	      cat $$< && echo "$(__)" ) > $$@
-    $/build/%.md: $/build/%
-	    ( echo "$(_h)## [$$*](build/$$*)" && \
-	      echo "$$(call _.,$$(suffix $$<))" && \
-	      cat $$< && echo "$(__)" ) > $$@
-    $/build/%.bringup.md: $/build/%.bringup
-	    ( echo "$(_h)## [$$*](build/$$*)" && \
-	      echo "$(_sh)" && \
-	      cat $$< && echo "$(__)" ) > $$@
-    $/build/%.tested.md: $/build/%.tested
-	    ( echo "$(_h)## [$$*](build/$$*)" && \
-	      echo "$(_sh)" && \
-	      cat $$< && echo "$(__)" ) > $$@
-endef
-$(eval $(META))
-
-# Report the project.
-define META
-    $/%: $/report.%
-	    @echo "# file://$$(subst /mnt/c/,/C:/,$$(realpath $$<)) $($/_BRANCH_STATUS)"
-    $/slides: $/slides.html
-	    @echo "# file://$$(subst /mnt/c/,/C:/,$$(realpath $$<)) $($/_BRANCH_STATUS)"
-endef
-$(eval $(META))
-$/slides.html: $/report.dzslides
-	mv $< $@
-$/report.gfm: $($/*.md) $($/_REPORT)
-$/report.html $/report.pdf $/report.dzslides: $($/*.md) $($/_REPORT)
-$/_file = $(foreach _,$1,[\`$_\`]($_))
-$/_exe = $(foreach _,$1,[\`$_\`]($_))
-$/_h_fixup := sed -E '/^$$|[.]{3}/d'
-define META
-    $/build/report.md: $/build/report.txt $/report
-	    echo "A build-here include-from-anywhere project based on [makemake](https://github.com/joakimbits/normalize)." > $$@
-	    echo "\n- \`make report pdf html slides review audit\`" >> $$@
-ifneq ($(strip $($/_EXE)),)
-	    echo "- \`./$($/_NAME)\`: $(call $/_file,$($/_LINKABLE:$/%=%))" >> $$@
-endif
-ifneq (,$(strip $($/*.py)))
-	    echo "- $(call $/_exe,$($/*.py:$/%=%))" >> $$@
-endif
-	    echo "$(_h)## Installation" >> $$@
-	    echo "$(_sh)" >> $$@
-	    echo "$$$$ make" >> $$@
-	    echo "$(__)" >> $$@
-ifneq (,$(strip $($/_EXE)))
-	    echo "- Installs \`./$($/_NAME)\`." >> $$@
-endif
-ifneq (,$(strip $($/*.py)))
-	    echo "- Installs $(call $/_exe,venv/bin/python3)." >> $$@
-	    echo "- Installs $(call $/_exe,$($/*.py:$/%=%))." >> $$@
-endif
-ifneq (,$($/_EXES))
-	    echo "$(_h)## Usage" >> $$@
-	    echo "$(_sh)" >> $$@
-	    for x in $($/_EXES:$/%=%) ; do \
-	      echo "\$$$$ true | $$$$x -h | $($/_h_fixup)" >> $$@ && \
-	      ( cd $/. && true | $$$$x -h ) > $$@.tmp && \
-	      $($/_h_fixup) $$@.tmp >> $$@ && rm $$@.tmp ; \
-	    done
-	    echo >> $$@
-	    echo "$(__)" >> $$@
-	    echo "$(_h)## Test" >> $$@
-	    echo "$(_sh)" >> $$@
-	    echo "\$$$$ make tested" >> $$@
-	    echo "$(__)" >> $$@
-endif
-ifneq (,$(strip $($/_EXE)))
-	    echo "- Tests \`./$($/_NAME)\`." >> $$@
-endif
-ifneq (,$(strip $($/*.py)))
-	    echo "- Verifies style and doctests in $(call $/_file,$($/*.py:$/%=%))." >> $$@
-endif
-ifneq (,$(strip $($/*.md)))
-	     echo "- Verifies doctests in $(call $/_file,$($/*.md:$/%=%))." >> $$@
-endif
-ifneq (,$(strip $($/_CODE)))
-	    echo "$(_h)## Result" >> $$@
-	    echo "$(_sh)" >> $$@
-	    echo "\$$$$ make report" >> $$@
-	    ( cd $/. && $(MAKE) report --no-print-directory ) >> $$@
-	    echo "$(__)" >> $$@
-	    echo "\n---\n" >> $$@
-endif
-endef
-$(eval $(META))
 $/build/report-details.md:
-	echo "$(_h)# Source code, installation and test result" >> $@
-
-# Document last release.
-$/old: $($/_OLD)report.gfm
-	@echo "# file://$(subst /mnt/c/,/C:/,$(realpath $<)) $($/_BASELINE_INFO)"
+	echo "$(_heading)# Source code, installation and test result" >> $@
 
 $($/_OLD)report.gfm: $($/_HOME)build/$($/_BASELINE)/Makefile
-	-( cd $(dir $@) && $(MAKE) report.gfm --no-print-directory )
+	mkdir -p $(dir $@) && ( cd $(dir $@) && $(MAKE) report.gfm --no-print-directory ) || touch $@
 
 # Use GPT for a release review.
-$/%: $/build/%.diff
-	cat $<
-	@echo "# file://$(subst /mnt/c/,/C:/,$(realpath $<)) $($/_CHANGES)"
-define META
-    $/build/audit.diff: $/build/prompt.diff | $($/venv/bin/python3)
-	    cat $$< > $$@
-	    $($/venv/bin/python3) -m makemake --prompt $$< $(GPT_MODEL) $(GPT_TEMPERATURE) $(GPT_BEARER_rot13) >> $$@
-endef
-$(eval $(META))
+$/build/audit.diff: $/makemake.py $/build/makemake.py.bringup $/build/prompt.diff
+	cat $(word 3,$^) > $@
+	( cd $(dir $<) && makemake.py --prompt build/prompt.diff $(GPT_MODEL) $(GPT_TEMPERATURE) $(GPT_BEARER_rot13) ) > $@
 $/build/prompt.diff: $/build/review.diff
 	$(PYTHON) $/makemake.py -c 'print(REVIEW)' > $@
 	echo "$$ $(MAKE) $/review" >> $@
@@ -774,12 +758,14 @@ $/build/review.diff: $/build/files.diff $/build/comments.diff $/build/report.dif
 	cat $^ > $@
 $/build/files.diff:
 	echo "# $($/_CHANGES_AUDIT)" > $@
+
 define META
-    $/build/comments.diff:
-	    echo "git --no-pager log --no-merges $($/_BASELINE)..HEAD $/." > $$@
-	    git --no-pager log --no-merges $($/_BASELINE)..HEAD $/. >> $$@
+    $$/build/comments.diff:
+	    echo "git --no-pager log --no-merges $$($/_BASELINE)..HEAD $/." > $$@
+	    git --no-pager log --no-merges $$($/_BASELINE)..HEAD $/. >> $$@
 endef
 $(eval $(META))
+
 $/build/report.diff: $($/_OLD)report.gfm $/report.gfm $/makemake.py
 	echo "diff -u -U 100000 $< $(word 2,$^) | fold-unchanged" > $@
 	( diff -u -U 100000 $< $(word 2,$^) | csplit -s - /----/ '{*}' && \

--- a/Makefile
+++ b/Makefile
@@ -746,9 +746,8 @@ $($/_OLD)report.gfm: $($/_HOME)build/$($/_BASELINE)/Makefile
 	mkdir -p $(dir $@) && ( cd $(dir $@) && $(MAKE) report.gfm --no-print-directory ) || touch $@
 
 # Use GPT for a release review.
-$/build/audit.diff: $/makemake.py $/build/makemake.py.bringup $/build/prompt.diff
-	cat $(word 3,$^) > $@
-	( cd $(dir $<) && makemake.py --prompt build/prompt.diff $(GPT_MODEL) $(GPT_TEMPERATURE) $(GPT_BEARER_rot13) ) > $@
+$/build/audit.diff: $/makemake.py $/build/prompt.diff $/build/makemake.py.bringup
+	( cd $(dir $<) && makemake.py --prompt build/prompt.diff $(GPT_MODEL) $(GPT_TEMPERATURE) $(GPT_BEARER_rot13) ) > $@ && cat $(word 2,$^) $@ || ( cat $@ && false )
 $/build/prompt.diff: $/build/review.diff
 	$(PYTHON) $/makemake.py -c 'print(REVIEW)' > $@
 	echo "$$ $(MAKE) $/review" >> $@

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ build/makemake.py.tested: makemake.py build/makemake.py.bringup
 	makemake.py --test > $@
 build/makemake.py.bringup: makemake.py | $(PYTHON)
 	mkdir -p build/ && \
-	$(PYTHON) -m pip install requests --no-warn-script-location > $@
+	$(PYTHON) -m pip install requests tiktoken --no-warn-script-location > $@
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ $ make pdf html slides
 - The generic Makefile builds exactly the same when included in a parent Makefile anywhere. 
 - It also isolates its own dependencies into a local python venv. 
 
+```sh
+$ python3 makemake.py --makemake --generic
+# normalize$ makemake.py --makemake --generic
+_Makefile := $(lastword $(MAKEFILE_LIST))
+/ := $(patsubst ./,,$(subst \,/,$(subst C:\,/c/,$(dir $(_Makefile)))))
+
+ifneq (clean,$(findstring clean,$(MAKECMDGOALS)))
+    $/project.mk: $/makemake.py
+	    curl https://raw.githubusercontent.com/joakimbits/normalize/better_mac_support/Makefile -o $@
+    $/makemake.py:
+	    curl https://raw.githubusercontent.com/joakimbits/normalize/better_mac_support/makemake.py -o $@
+endif
+
+-include $/project.mk
+
+```
+
+---
+
 There is a simpler variant:
 
 - It can only be included from within the same directory, without a venv.
@@ -32,8 +51,7 @@ build/makemake.py.tested: makemake.py build/makemake.py.bringup
 	makemake.py --test > $@
 build/makemake.py.bringup: makemake.py | $(PYTHON)
 	mkdir -p build/ && \
-	$(PYTHON) -m pip install requests --no-warn-script-location > $@ && \
-	$(PYTHON) makemake.py --shebang >> $@
+	$(PYTHON) -m pip install requests --no-warn-script-location > $@
 
 ```
 

--- a/example/README.md
+++ b/example/README.md
@@ -30,8 +30,7 @@ Hello world!
 $ cat build/greeter.py.mk
 $/build/greeter.py.bringup: $/greeter.py $/build/greeter.py.mk | $/venv/bin/python3
 	( cd $(dir $<). && make example --no-print-directory ) > $@ && \
-	$(dir $<)venv/bin/python3 -m pip install fire --no-warn-script-location >> $@ && \
-	$(dir $<)venv/bin/python3 $< --shebang >> $@
+	$(dir $<)venv/bin/python3 -m pip install fire --no-warn-script-location >> $@
 
 $ greeter.py --help | awk '{ print "\t" $0 }'
 	usage: greeter.py [-h] [--makemake] [--generic] [--dep DEP] [-c C]


### PR DESCRIPTION
```
$ make audit
Retrying after compressing -:(another 267 lines dropped here)
Waiting 9.638s for gpt-3.5-turbo-16k to accept new requests
:
Retrying after compressing -:(another 225 lines added here)
Waiting 13.877s for gpt-3.5-turbo-16k to accept new requests
gpt-3.5-turbo-16k-0613 chat.completion chatcmpl-92fvMVEr3WGkkP0Ipq1CVGmjgww4S prompted 16251 -> completed 135:
Release Summary:
- Upgraded the makefile and makemake.py to support different OSes and to make it easier to report, review, and maintain the generic project builder template.
- Refactored the --generic template from makemake.py into a generic Makefile.
- Removed the requirement for PYTHON in the --generic builder.
- Made subproject makers from the main project and removed obsolete subproject makers.
- Added support for any OS, CPU, and PYTHON.
- Improved the help message.
- Added a typical C programming example.
- Added a typical Python programming example.
- Fixed the bug of nonlocal path in local documentation.

Release Title: Enhanced Project
```