### PR TITLE
Focus on main project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ $/_ACTIVE_SUBPROJECTS := $(dir $(foreach d,$($/_SUBPROJECTS),$(wildcard $/$dMake
 # Define symbolic targets we might want to use to represent (all) its dependencies
 # Do not use such a phony as a dependency unless you also need the target rebuilt every time.
 define META
-    .PHONY: $/all $$/bringup $/tested $/old $/new $/slides $/clean $/clean/keep_venv
+    .PHONY: $/make $/list $$/bringup $/tested $/old $/new $/slides $/clean $/clean/keep_venv
     .PHONY: $venv/ $/syntax $/style
     $/make: | $($/_ACTIVE_SUBPROJECTS:%=%make)
     $/bringup: | $($/_ACTIVE_SUBPROJECTS:%=%bringup)
@@ -805,6 +805,10 @@ $/build/report.diff: $($/_OLD)report.gfm $/report.gfm $/makemake.py
 	    done ; \
 	  rm xx**; ) >> $@
 endif # building
+
+# List all targets that needs rebuilding and stop
+$/list: $($/Makefile)
+	make -f $< -dn MAKE=: $(filter-out $@,$(MAKECMDGOALS)) | sed -rn "s/^ *Must remake target '(.*)'\.$$/\1/p" && false
 
 ## Finally attempt to include all bringup files and sub-projects
 # Note: Subprojects modify $/, so this has to be the last command using it as a prefix here.

--- a/README.md
+++ b/README.md
@@ -1,55 +1,46 @@
-## Tool for generating build dependencies: makemake.py
+## Tool for using and reporting arbitrary nested projects 
 
 ---
 
 ```
-$ python3 makemake.py --makemake --generic > Makefile && make
+$ GH="https://raw.githubusercontent.com"; curl $GH/joakimbits/normalize/main/template/Makefile -o Makefile && make
 ```
 
-- Compiles local sources and installs a local venv ready to run all local python modules.
+- Create executables from all source files.
+- Recursively also in sub-directories with a README.md file, or any other .md file.
 
 ```
 $ make pdf html slides
 ```
 
-- Tests the python and command line usage examples, and generates project reports.
+- Tests all usage examples, and generates project reports if they all PASS.
 
 ---
-
-- The generic Makefile builds exactly the same when included in a parent Makefile anywhere. 
-- It also isolates its own dependencies into a local python venv. 
-
-```sh
-$ python3 makemake.py --makemake --generic
-# normalize$ makemake.py --makemake --generic
-_Makefile := $(lastword $(MAKEFILE_LIST))
-/ := $(patsubst %build/,%,$(patsubst ./%,%,$(patsubst C:/%,/c/%,$(subst \,/,$(dir $(Makefile))))))
-$/bringup:
-$/build/project.mk:
-	mkdir -p $(dir $@) && curl https://raw.githubusercontent.com/joakimbits/normalize/main/Makefile -o $@
--include $/build/project.mk
 
 ```
+$ make old new review audit
+```
+
+- Analyze changes and use GPT to generate release notes.
 
 ---
 
-There is a simpler variant:
-
-- It can only be included from within the same directory, without a venv.
-
----
+Standalone variant:
 
 ```sh
-$ python3 makemake.py --makemake
-all: build/makemake.py.tested
-build/makemake.py.tested: makemake.py build/makemake.py.bringup
-	makemake.py --test > $@
-build/makemake.py.bringup: makemake.py | $(PYTHON)
+$ build.py --makemake
+bringup: build/build.py.bringup
+tested: build/build.py.tested
+build/build.py.tested: build.py build/build.py.shebang build/build.py.mk
+	build.py --test > $@
+build/build.py.shebang: build.py build/build.py.bringup
+	$(PYTHON) build.py --shebang > $@
+build/build.py.bringup: build.py | $(PYTHON)
 	mkdir -p build/ && \
 	$(PYTHON) -m pip install requests tiktoken --no-warn-script-location > $@
 
 ```
 
-- Python version 3.7 or later is required.
+- Python version 3.8 or later is required.
 
 [example/README.md](example/README.md)

--- a/example/greeter.py
+++ b/example/greeter.py
@@ -8,7 +8,7 @@ fire
 import subprocess
 import argparse
 
-import makemake
+import build
 import fire
 
 def run(cmd):
@@ -32,7 +32,7 @@ def hello(*world):
         print(f"Hello {' '.join(world)}!")
     else:
         print("Hello from greeter.py!")
-        print(run(f"{makemake.path}example"))
+        print(run(f"{build.path}example"))
 
 EXAMPLES = """
 $ ./greeter.py
@@ -47,10 +47,10 @@ Hello world!
 if __name__ == '__main__':
     argparser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=makemake.brief(),
+        description=build.brief(),
         epilog=f"Examples:{EXAMPLES}")
     argparser.add_argument('world', nargs=argparse.REMAINDER, help=(
         "hello(world)"))
-    makemake.add_arguments(argparser)
+    build.add_arguments(argparser)
     args = argparser.parse_args()
     fire.Fire(hello)

--- a/example2/factorize.py
+++ b/example2/factorize.py
@@ -9,7 +9,7 @@ fire
 """
 import argparse
 
-import makemake
+import build
 import fire
 
 def fizz3fuzz5(*numbers):
@@ -35,9 +35,9 @@ Buzz
 if __name__ == '__main__':
     argparser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=makemake.brief(),
+        description=build.brief(),
         epilog=f"Examples:{EXAMPLES}")
-    makemake.add_arguments(argparser)
+    build.add_arguments(argparser)
     argparser.add_argument('number', nargs=argparse.REMAINDER, help=fizz3fuzz5.__doc__)
     args = argparser.parse_args()
     fire.Fire(fizz3fuzz5)


### PR DESCRIPTION
'make audit' with gpt-3.5 struggled with attending to the main project when a subproject is not affected at all by the changes.

Focus on the main project changes only. Test subprojects but do not review them.

Add `make list`: List dependencies remaining to be built.

Workaround a limitation with with too huge prompts sent to gpt-3.5: A single prompt triggers rate limit.

Prepare for moving makemake.py it into the build directory by naming it build.py.


